### PR TITLE
Update to dnsdbv2

### DIFF
--- a/v2/pkg/passive/sources_test.go
+++ b/v2/pkg/passive/sources_test.go
@@ -97,6 +97,7 @@ var (
 		"certspotter",
 		"crtsh",
 		"dnsdumpster",
+		"dnsdb",
 		"digitorus",
 		"hackertarget",
 		"passivetotal",


### PR DESCRIPTION
Changes

- Update the dnsdbV2. I used V2 rather than flex because the results with v2 are more full, with all rrtypes
- Mark dnsdb as being able to handle recursive domains, e.g. `iad1.fsi.io`, not just `fsi.io`, because it can
- Set the `?swclient=` query param
- Properly use the `?limit=` and `?offset=` query params according to the documentation
- Improve the way the response is converted to json.

I'll rebase it into something nice and neat before opening the real PR with subfinder.